### PR TITLE
テスト用のリソース割り当ててエラー出てたのでコメントアウト

### DIFF
--- a/app/src/earthquake/EarthQuakeQuick.py
+++ b/app/src/earthquake/EarthQuakeQuick.py
@@ -25,7 +25,7 @@ class EarthQuakeQuick:
         if (self.__xml_url == None):
             return False
         parsed = self.__eq_c.parse_url(self.__xml_url)
-        parsed = self.__eq_c.parse_url(url)
+        # parsed = self.__eq_c.parse_url(url)
 
         control = parsed[0]
         result["title"] = control[0].text


### PR DESCRIPTION
下記エラーが出ていた。原因は震度速報で詳細URLを取得する時にテスト用のリソースを使っていた。このリソースは数週間すると気象庁のサーバーから削除されるため404が出た。これにより震源・震度に関する情報も取得できず今朝方の地震が取得できなかった。

```
Traceback (most recent call last):
  File "earthQuake.py", line 117, in <module>
    eq = EarthQuake()
  File "earthQuake.py", line 23, in __init__
    self.__eq_q_data         = self.__eq_q.get_eq()
  File "/home/goppy/earth-quake-server/app/src/earthquake/EarthQuakeQuick.py", line 28, in get_eq
    parsed = self.__eq_c.parse_url(url)
  File "/home/goppy/earth-quake-server/app/src/earthquake/EarthQuakeCommon.py", line 41, in parse_url
    with urllib.request.urlopen(req) as response:
  File "/home/goppy/.pyenv/versions/3.8.2/lib/python3.8/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/home/goppy/.pyenv/versions/3.8.2/lib/python3.8/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/home/goppy/.pyenv/versions/3.8.2/lib/python3.8/urllib/request.py", line 640, in http_response
    response = self.parent.error(
  File "/home/goppy/.pyenv/versions/3.8.2/lib/python3.8/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/home/goppy/.pyenv/versions/3.8.2/lib/python3.8/urllib/request.py", line 502, in _call_chain
    result = func(*args)
  File "/home/goppy/.pyenv/versions/3.8.2/lib/python3.8/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
```