### PR TITLE
緊急地震速報取得スクリプト作成

### DIFF
--- a/eew/Eew.py
+++ b/eew/Eew.py
@@ -20,6 +20,8 @@ class Eew():
         extension = '.json'
         nowtime  = self.__get_current_date()
         endpoint = self.__common_uri + str(nowtime) + extension
+        # テスト用
+        # endpoint = self.__common_uri + str(20200730093733) + extension
         return endpoint
 
 

--- a/eew/Eew.py
+++ b/eew/Eew.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+import requests
+
+
+class Eew():
+    def __init__(self):
+        self.__common_uri = 'http://www.kmoni.bosai.go.jp/webservice/hypo/eew/'
+
+
+    def get_json_data(self):
+        endpoint = self.__create_endpoint()
+        json_data = requests.get(endpoint).json()
+        return json_data
+
+
+    def __create_endpoint(self):
+        extension = '.json'
+        nowtime  = self.__get_current_date()
+        endpoint = self.__common_uri + str(nowtime) + extension
+        return endpoint
+
+
+    def __get_current_date(self):
+        date_time = datetime.now().strftime('%Y%m%d%H%M%S')
+        return date_time

--- a/eew/eew.sh
+++ b/eew/eew.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export PATH=/home/$(whoami)/.pyenv/bin:$PATH
+eval "$(pyenv init -)"
+srcPath=/home/$(whoami)/earth-quake-server/eew
+
+python3 ${srcPath}/main.py

--- a/eew/main.py
+++ b/eew/main.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+from slack import Slacks
+from Eew import Eew
+
+
+def main():
+    eew = Eew()
+    slacks = Slacks()
+    json_data = eew.get_json_data()
+    slacks.post_slack(json_data)
+
+
+if __name__ == '__main__':
+    main()

--- a/eew/slack.py
+++ b/eew/slack.py
@@ -25,31 +25,33 @@ class Slacks():
             alertflg    = str(json_data['alertflg'])
             user_name = self.__title + '(' + alertflg + ')'
             body      = self.__create_body(__json_data)
-            icon = self.__create_icon(__json_data)
+            icon      = self.__create_icon(__json_data)
             # 緊急地震速報かつ第一報かつ予想震度が2以上ならslackに通知する
             # if hypo_type == 'eew' and (report_num == '1' or alertflg =='警報'):
             if hypo_type == 'eew' and report_num == '1':
+                slack_conn = slackweb.Slack(url=self.__token)
                 slack_conn.notify(text=body, username=user_name, icon_emoji=icon)
 
 
     def __create_body(self, json_data):
-        origin_time   = self.__parse_time(str(json_data('origin_time')))
-        region_name   = str(json_data('region_name'))
-        depth         = str(json_data.get('depth'))
-        magnitude     = float(json_data.get('magnitude'))
-        latitude      = float(json_data.get('latitude'))
-        longitude     = float(json_data.get('longitude'))
-        calcintensity = str(json_data.get('calcintensity'))
-        is_cancel     = bool(json_data.get('is_cancel'))
+        origin_time   = self.__parse_time(str(json_data['origin_time']))
+        region_name   = str(json_data['region_name'])
+        depth         = str(json_data['depth'])
+        magunitude    = float(json_data['magunitude'])
+        latitude      = float(json_data['latitude'])
+        longitude     = float(json_data['longitude'])
+        calcintensity = str(json_data['calcintensity'])
+        is_cancel     = bool(json_data['is_cancel'])
 
         # 本文のパーツ作成
+        body_mention       = "<!here>" + "\n\n"
         body_origin_time   = "地震発生時刻： " + " *" + origin_time + "* \n\n"
         body_calcintensity = "推定最大震度： " + " *" + calcintensity + "* \n\n"
-        body_magnitude     = "マグニチュード： M" + " *" + magnitude + "* \n\n"
+        body_magunitude    = "マグニチュード： M" + " *" + str(magunitude) + "* \n\n"
         body_region        = "震央地： " +  region_name + "\n"
         body_coor          = "経緯度： " + "東経 " + str(longitude) + " 北緯 " + str(latitude) + "\n"
         body_depth         = "震源の深さ： " + depth + "\n\n"
-        body               = body_origin_time + body_calcintensity + body_magnitude + body_region + body_coor + body_depth
+        body               = body_mention + body_origin_time + body_calcintensity + body_magunitude + body_region + body_coor + body_depth
         return body
 
 

--- a/eew/slack.py
+++ b/eew/slack.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import config
+import slackweb
+import sys, os
+import json
+import requests
+
+
+class Slacks():
+    def __init__(self):
+        self.__token  = config.incoming_webhook_url
+        self.__minint = 2
+        # 以下はslack系
+        self.__title = "緊急地震速報"
+        self.__icons = ["one", "two", "three", "four", "five", "six", "seven"]
+
+
+    def post_slack(self, json_data):
+        __json_data = json_data
+        hypo_type   = str(json_data['request_hypo_type'])
+        report_num  = str(json_data['report_num'])
+        if ('alertflg' in json_data.keys()):
+            alertflg    = str(json_data['alertflg'])
+            user_name = self.__title + '(' + alertflg + ')'
+            body      = self.__create_body(__json_data)
+            icon = self.__create_icon(__json_data)
+            # 緊急地震速報かつ第一報かつ予想震度が2以上ならslackに通知する
+            # if hypo_type == 'eew' and (report_num == '1' or alertflg =='警報'):
+            if hypo_type == 'eew' and report_num == '1':
+                slack_conn.notify(text=body, username=user_name, icon_emoji=icon)
+
+
+    def __create_body(self, json_data):
+        origin_time   = self.__parse_time(str(json_data('origin_time')))
+        region_name   = str(json_data('region_name'))
+        depth         = str(json_data.get('depth'))
+        magnitude     = float(json_data.get('magnitude'))
+        latitude      = float(json_data.get('latitude'))
+        longitude     = float(json_data.get('longitude'))
+        calcintensity = str(json_data.get('calcintensity'))
+        is_cancel     = bool(json_data.get('is_cancel'))
+
+        # 本文のパーツ作成
+        body_origin_time   = "地震発生時刻： " + " *" + origin_time + "* \n\n"
+        body_calcintensity = "推定最大震度： " + " *" + calcintensity + "* \n\n"
+        body_magnitude     = "マグニチュード： M" + " *" + magnitude + "* \n\n"
+        body_region        = "震央地： " +  region_name + "\n"
+        body_coor          = "経緯度： " + "東経 " + str(longitude) + " 北緯 " + str(latitude) + "\n"
+        body_depth         = "震源の深さ： " + depth + "\n\n"
+        body               = body_origin_time + body_calcintensity + body_magnitude + body_region + body_coor + body_depth
+        return body
+
+
+    # YYYYMMDDhh24msをYYYY/MM/DD hh24:mm:ssに変換する
+    def __parse_time(self, date):
+        dt = date[:4] + "/" + date[4:6] + "/" + date[6:8] + " " + date[8:10] + ":" + date[10:12] + ":" + date[12:14]
+        return dt
+
+
+    # slackアイコン
+    def __create_icon(self, json_data):
+        intensity = str(json_data['calcintensity'])
+        icon = ":" + self.__icons[int(intensity[:1])-1] + ":"
+        return icon

--- a/eew/slack.py
+++ b/eew/slack.py
@@ -21,14 +21,14 @@ class Slacks():
         __json_data = json_data
         hypo_type   = str(json_data['request_hypo_type'])
         report_num  = str(json_data['report_num'])
+        intensity   = int(str(json_data['calcintensity'])[:1])
         if ('alertflg' in json_data.keys()):
             alertflg    = str(json_data['alertflg'])
             user_name = self.__title + '(' + alertflg + ')'
             body      = self.__create_body(__json_data)
             icon      = self.__create_icon(__json_data)
             # 緊急地震速報かつ第一報かつ予想震度が2以上ならslackに通知する
-            # if hypo_type == 'eew' and (report_num == '1' or alertflg =='警報'):
-            if hypo_type == 'eew' and report_num == '1':
+            if hypo_type == 'eew' and ((report_num == '1' and intensity >= 2) or alertflg =='警報'):
                 slack_conn = slackweb.Slack(url=self.__token)
                 slack_conn.notify(text=body, username=user_name, icon_emoji=icon)
 


### PR DESCRIPTION
緊急地震速報を取得するスクリプトを作った
防災科研が出している新強震モニタから非公表のjsonデータを毎秒取得して条件に合う場合のみslackに通知するスクリプト

## 別途用意するもの
* cron
```
#緊急地震速報のcron(1秒ごとに取得)
* * * * * goppy for i in `seq 0 1 59`;do (sleep ${i}; sh /home/${username}/earth-quake-server/eew/eew.sh >> /tmp/eew_error.log 2>&1) & done;
```

* config.py(他のファイルと同階層)
  * incoming_webhookのtoken(url)を保存する
  * 変数名は `incoming_webhook_url`
